### PR TITLE
Add body parser for HttpRequest

### DIFF
--- a/src/Request/HttpRequest.php
+++ b/src/Request/HttpRequest.php
@@ -1,193 +1,271 @@
 <?php
 
-    namespace ObjectivePHP\Message\Request;
+namespace ObjectivePHP\Message\Request;
 
-    use ObjectivePHP\Message\Request\Parameter\Container\HttpParameterContainer;
-    use ObjectivePHP\Message\Request\Parameter\Container\ParameterContainerInterface;
-    use ObjectivePHP\Router\MatchedRoute;
-    use Psr\Http\Message\StreamInterface;
-    use Zend\Diactoros\Request;
+use ObjectivePHP\Message\Request\Parser\ParserInterface;
+use RuntimeException;
+use TypeError;
+use ObjectivePHP\Message\Request\Parameter\Container\HttpParameterContainer;
+use ObjectivePHP\Message\Request\Parameter\Container\ParameterContainerInterface;
+use ObjectivePHP\Message\Request\Parser\JsonParser;
+use ObjectivePHP\Router\MatchedRoute;
+use Psr\Http\Message\StreamInterface;
+use Zend\Diactoros\Request;
+
+/**
+ * Class HttpRequest
+ *
+ * @package ObjectivePHP\Message\Request
+ */
+class HttpRequest extends Request implements RequestInterface
+{
 
     /**
-     * Class HttpRequest
-     *
-     * @package ObjectivePHP\Message\Request
+     * @var HttpParameterContainer
      */
-    class HttpRequest extends Request implements RequestInterface
+    protected $parameters;
+
+    /**
+     * @var string
+     */
+    protected $route;
+
+    /**
+     * @var mixed
+     */
+    protected $action;
+
+    /**
+     * @var MatchedRoute
+     */
+    protected $matchedRoute;
+
+    /**
+     * @var
+     */
+    protected $get = [];
+
+    /**
+     * @var array
+     */
+    protected $post = [];
+
+    /**
+     * @var bool|array
+     */
+    protected $bodyParsed = false;
+
+    /**
+     * @var array
+     */
+    protected $bodyParsers = [];
+
+    /**
+     * @var array
+     */
+    protected $bodyParsersList = [
+        'application/json' => JsonParser::class,
+    ];
+
+    /**
+     * @param null|string                     $uri     URI for the request, if any.
+     * @param null|string                     $method  HTTP method for the request, if any.
+     * @param string|resource|StreamInterface $body    Message body, if any.
+     * @param array                           $headers Headers for the message, if any.
+     *
+     * @throws \InvalidArgumentException for any invalid value.
+     */
+    public function __construct($uri = null, $method = null, $body = 'php://input', array $headers = [])
+    {
+        $this->loadParsers();
+        parent::__construct($uri, $method, $body, $headers);
+    }
+
+    /**
+     * In charge to load every parser in the attributes bodyParsers
+     */
+    protected function loadParsers()
+    {
+        foreach ($this->bodyParsersList as $type => $parser) {
+            if (is_subclass_of($parser, ParserInterface::class)) {
+                $this->registerMediaTypeParser($type, new $parser());
+            }
+        }
+    }
+
+    /**
+     * @param $mediaType
+     * @param callable $callable
+     */
+    public function registerMediaTypeParser($mediaType, callable $callable)
+    {
+        $this->bodyParsers[(string)$mediaType] = $callable;
+    }
+
+    /**
+     * @return array|bool|null
+     * @throws \TypeError
+     */
+    public function getParsedBody()
+    {
+        if ($this->bodyParsed !== false) {
+            return $this->bodyParsed;
+        }
+
+        $contentsBody = (string)$this->getBody();
+        if (!$contentsBody) {
+            return null;
+        }
+
+        $mediaType = $this->getHeader('content-type');
+        $mediaType = $mediaType[0] ?? null;
+
+        if (empty($mediaType)) {
+            throw new RuntimeException('Request media type can not be null');
+        }
+
+        if (isset($this->bodyParsers[$mediaType]) === true) {
+            $parsed = $this->bodyParsers[$mediaType]($contentsBody);
+            if (!is_null($parsed) && !is_object($parsed) && !is_array($parsed)) {
+                throw new TypeError(
+                    'Request body media type parser return value must be an array, an object, or null'
+                );
+            }
+            $this->bodyParsed = $parsed;
+            return $this->bodyParsed;
+        }
+        return null;
+    }
+
+    /**
+     * Proxy to ParameterContainerInterface::getParam()
+     *
+     * @param $param    string      Parameter name
+     * @param $param    mixed       Default value
+     * @param $origin   string       Source name (for instance 'get' for HTTP param)
+     *
+     * @return mixed
+     */
+    public function getParam($param, $default = null, $origin = null)
+    {
+        $this->getParameters()->get($param, $default, $origin);
+    }
+
+    /**
+     * @return HttpParameterContainer
+     */
+    public function getParameters() : ParameterContainerInterface
     {
 
-        /**
-         * @var HttpParameterContainer
-         */
-        protected $parameters;
-
-        /**
-         * @var string
-         */
-        protected $route;
-
-        /**
-         * @var mixed
-         */
-        protected $action;
-
-        /**
-         * @var MatchedRoute
-         */
-        protected $matchedRoute;
-
-        /**
-         * @var
-         */
-        protected $get = [];
-
-        /**
-         * @var array
-         */
-        protected $post = [];
-
-        /**
-         * @param null|string                     $uri     URI for the request, if any.
-         * @param null|string                     $method  HTTP method for the request, if any.
-         * @param string|resource|StreamInterface $body    Message body, if any.
-         * @param array                           $headers Headers for the message, if any.
-         *
-         * @throws \InvalidArgumentException for any invalid value.
-         */
-        public function __construct($uri = null, $method = null, $body = 'php://input', array $headers = [])
+        if (is_null($this->parameters))
         {
-            parent::__construct($uri, $method, $body, $headers);
+            // build default parameter container from request
+            $this->parameters = new HttpParameterContainer($this);
         }
 
-        /**
-         * Proxy to ParameterContainerInterface::getParam()
-         *
-         * @param $param    string      Parameter name
-         * @param $param    mixed       Default value
-         * @param $origin   string       Source name (for instance 'get' for HTTP param)
-         *
-         * @return mixed
-         */
-        public function getParam($param, $default = null, $origin = null)
-        {
-            $this->getParameters()->get($param, $default, $origin);
-        }
-
-        /**
-         * @return HttpParameterContainer
-         */
-        public function getParameters() : ParameterContainerInterface
-        {
-
-            if (is_null($this->parameters))
-            {
-                // build default parameter container from request
-                $this->parameters = new HttpParameterContainer($this);
-            }
-
-            return $this->parameters;
-        }
-
-        /**
-         * @param HttpParameterContainer $parameters
-         */
-        public function setParameters(ParameterContainerInterface $parameters)
-        {
-            $this->parameters = $parameters;
-
-            return $this;
-        }
-
-
-
-        /**
-         * @return string
-         */
-        public function getRoute()
-        {
-            return $this->route;
-        }
-
-        /**
-         * @param string $route
-         *
-         * @return $this
-         */
-        public function setRoute($route)
-        {
-            $this->route = $route;
-
-            return $this;
-        }
-
-        /**
-         * @return mixed
-         */
-        public function getAction()
-        {
-            return $this->action;
-        }
-
-        /**
-         * @param mixed $action
-         */
-        public function setAction($action)
-        {
-            $this->action = $action;
-        }
-
-        /**
-         * @return mixed
-         */
-        public function getGet()
-        {
-            return $this->get;
-        }
-
-        /**
-         * @param mixed $get
-         */
-        public function setGet(array $get)
-        {
-            $this->get = $get;
-
-            return $this;
-        }
-
-        /**
-         * @return array
-         */
-        public function getPost()
-        {
-            return $this->post;
-        }
-
-        /**
-         * @param array $post
-         */
-        public function setPost(array $post)
-        {
-            $this->post = $post;
-
-            return $this;
-        }
-
-        /**
-         * @return mixed
-         */
-        public function getMatchedRoute()
-        {
-            return $this->matchedRoute;
-        }
-
-        /**
-         * @param mixed $matchedRoute
-         */
-        public function setMatchedRoute(MatchedRoute $matchedRoute)
-        {
-            $this->matchedRoute = $matchedRoute;
-
-            return $this;
-        }
-
+        return $this->parameters;
     }
+
+    /**
+     * @param HttpParameterContainer $parameters
+     */
+    public function setParameters(ParameterContainerInterface $parameters)
+    {
+        $this->parameters = $parameters;
+
+        return $this;
+    }
+
+
+
+    /**
+     * @return string
+     */
+    public function getRoute()
+    {
+        return $this->route;
+    }
+
+    /**
+     * @param string $route
+     *
+     * @return $this
+     */
+    public function setRoute($route)
+    {
+        $this->route = $route;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getAction()
+    {
+        return $this->action;
+    }
+
+    /**
+     * @param mixed $action
+     */
+    public function setAction($action)
+    {
+        $this->action = $action;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getGet()
+    {
+        return $this->get;
+    }
+
+    /**
+     * @param mixed $get
+     */
+    public function setGet(array $get)
+    {
+        $this->get = $get;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPost()
+    {
+        return $this->post;
+    }
+
+    /**
+     * @param array $post
+     */
+    public function setPost(array $post)
+    {
+        $this->post = $post;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getMatchedRoute()
+    {
+        return $this->matchedRoute;
+    }
+
+    /**
+     * @param mixed $matchedRoute
+     */
+    public function setMatchedRoute(MatchedRoute $matchedRoute)
+    {
+        $this->matchedRoute = $matchedRoute;
+
+        return $this;
+    }
+
+}

--- a/src/Request/HttpRequest.php
+++ b/src/Request/HttpRequest.php
@@ -53,7 +53,7 @@ class HttpRequest extends Request implements RequestInterface
     /**
      * @var bool|array
      */
-    protected $bodyParsed = false;
+    protected $parsedBody = false;
 
     /**
      * @var array
@@ -108,8 +108,8 @@ class HttpRequest extends Request implements RequestInterface
      */
     public function getParsedBody()
     {
-        if ($this->bodyParsed !== false) {
-            return $this->bodyParsed;
+        if ($this->parsedBody !== false) {
+            return $this->parsedBody;
         }
 
         $contentsBody = (string)$this->getBody();
@@ -131,8 +131,8 @@ class HttpRequest extends Request implements RequestInterface
                     'Request body media type parser return value must be an array, an object, or null'
                 );
             }
-            $this->bodyParsed = $parsed;
-            return $this->bodyParsed;
+            $this->parsedBody = $parsed;
+            return $this->parsedBody;
         }
         return null;
     }

--- a/src/Request/Parser/JsonParser.php
+++ b/src/Request/Parser/JsonParser.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ObjectivePHP\Message\Request\Parser;
+
+/**
+ * Class JsonParser
+ * @package ObjectivePHP\Message\Request\Parser
+ */
+class JsonParser implements ParserInterface
+{
+    /**
+     * @param mixed $data
+     * @return array
+     */
+    public function __invoke($data): array
+    {
+        $parsed = json_decode($data, true);
+        return !is_array($parsed) ? [] : $parsed;
+    }
+}

--- a/src/Request/Parser/ParserInterface.php
+++ b/src/Request/Parser/ParserInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ObjectivePHP\Message\Request\Parser;
+
+/**
+ * Interface ParserInterface
+ * @package ObjectivePHP\Message\Request\Parser
+ */
+interface ParserInterface
+{
+    /**
+     * @param mixed$data
+     * @return array
+     */
+    public function __invoke($data): array;
+}

--- a/tests/Message/Request/HttpRequestTest.php
+++ b/tests/Message/Request/HttpRequestTest.php
@@ -1,18 +1,242 @@
 <?php
-    
 
-    use ObjectivePHP\Message\Request\HttpRequest;
-    use ObjectivePHP\Message\Request\Parameter\Container\HttpParameterContainer;
+use ObjectivePHP\Message\Request\HttpRequest;
+use ObjectivePHP\Message\Request\Parameter\Container\HttpParameterContainer;
+use ObjectivePHP\Message\Request\Parser\JsonParser;
+use ObjectivePHP\Message\Request\Parser\ParserInterface;
 
-    class HttpRequestTest extends PHPUnit_Framework_TestCase
+class HttpRequestTest extends PHPUnit_Framework_TestCase
+{
+    /** @var HttpRequest */
+    protected $instance;
+
+    public function setUp()
     {
-
-
-        public function testGetParametersContainerReturnsDefaultContainer()
-        {
-            $request = new HttpRequest();
-
-            $this->assertInstanceOf(HttpParameterContainer::class, $request->getParameters());
-        }
-
+        $this->instance =  $this->instance = $this->getMockBuilder(HttpRequest::class)
+            ->disableOriginalConstructor()
+            ->setMethods(null)
+            ->getMock();
     }
+
+    public function tearDown()
+    {
+        $this->instance = null;
+    }
+
+    public function testGetParametersContainerReturnsDefaultContainer()
+    {
+        $request = new HttpRequest();
+
+        $this->assertInstanceOf(HttpParameterContainer::class, $request->getParameters());
+    }
+
+    public function testBodyParsersList()
+    {
+        $expectedList = [
+            'application/json' => JsonParser::class
+        ];
+
+        $propertyBodyParsersList = new ReflectionProperty($this->instance, 'bodyParsersList');
+        $propertyBodyParsersList->setAccessible(true);
+
+        $this->assertEquals($expectedList, $propertyBodyParsersList->getValue($this->instance));
+    }
+
+    public function testRegisterMediaTypeParser()
+    {
+        $this->instance = $this->getMockBuilder(HttpRequest::class)
+            ->disableOriginalConstructor()
+            ->setMethods(null)
+            ->getMock();
+        $fixtureMediaType = 'application/json';
+
+        $fixtureCallable = function() {
+            return true;
+        };
+
+        $expectedBodyParsers = [
+            'application/json' => $fixtureCallable,
+        ];
+
+        $this->instance->registerMediaTypeParser($fixtureMediaType, $fixtureCallable);
+
+        $propertyBodyParsers = new ReflectionProperty($this->instance, 'bodyParsers');
+        $propertyBodyParsers->setAccessible(true);
+
+        $this->assertEquals($expectedBodyParsers, $propertyBodyParsers->getValue($this->instance));
+    }
+
+    public function testLoadParsers()
+    {
+        $bodyParsersList = [
+            'application/json' => JsonParser::class,
+            'application/xml' => stdClass::class
+        ];
+
+        $this->instance = $this->getMockBuilder(HttpRequest::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['registerMediaTypeParser'])
+            ->getMock();
+
+        $propertyBodyParsersList = new ReflectionProperty($this->instance, 'bodyParsersList');
+        $propertyBodyParsersList->setAccessible(true);
+        $propertyBodyParsersList->setValue($this->instance, $bodyParsersList);
+
+        $this->instance->expects($this->once())
+            ->method('registerMediaTypeParser');
+
+        $method = new ReflectionMethod($this->instance, 'loadParsers');
+        $method->setAccessible(true);
+        $method->invoke($this->instance);
+    }
+
+    public function testGetParsedBodyExisting()
+    {
+        $fixtureBodyParsed = [];
+
+        $propertyBodyParsed = new ReflectionProperty($this->instance, 'bodyParsed');
+        $propertyBodyParsed->setAccessible(true);
+        $propertyBodyParsed->setValue($this->instance, $fixtureBodyParsed);
+
+        $this->assertEquals($fixtureBodyParsed, $this->instance->getParsedBody());
+    }
+
+    public function testGetParsedBodyNoBody()
+    {
+        $this->instance = $this->getMockBuilder(HttpRequest::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getBody'])
+            ->getMock();
+
+        $this->instance->expects($this->once())
+            ->method('getBody')
+            ->willReturn(null);
+
+        $this->assertNull($this->instance->getParsedBody());
+    }
+
+    public function testGetParsedBodyNoMediaType()
+    {
+        $this->instance = $this->getMockBuilder(HttpRequest::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getBody', 'getHeader'])
+            ->getMock();
+
+        $this->instance->expects($this->once())
+            ->method('getBody')
+            ->willReturn('body');
+
+        $this->instance->expects($this->once())
+            ->method('getHeader')
+            ->with('content-type')
+            ->willReturn([]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Request media type can not be null');
+
+        $this->instance->getParsedBody();
+    }
+
+    public function testGetParsedBodyBadParsing()
+    {
+        $fixtureMediaType = 'application/json';
+        $fixtureBody = 'body';
+
+        $mockParser = $this->getMockBuilder(stdClass::class)
+            ->setMethods(['__invoke'])
+            ->getMock();
+
+        $mockParser->expects($this->once())
+            ->method('__invoke')
+            ->with($fixtureBody)
+            ->willReturn('');
+
+        $this->instance = $this->getMockBuilder(HttpRequest::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getBody', 'getHeader'])
+            ->getMock();
+
+        $this->instance->expects($this->once())
+            ->method('getBody')
+            ->willReturn($fixtureBody);
+
+        $this->instance->expects($this->once())
+            ->method('getHeader')
+            ->with('content-type')
+            ->willReturn([$fixtureMediaType]);
+
+        $propertyBodyParsers = new ReflectionProperty($this->instance, 'bodyParsers');
+        $propertyBodyParsers->setAccessible(true);
+        $propertyBodyParsers->setValue($this->instance, ['application/json' => $mockParser]);
+
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessage('Request body media type parser return value must be an array, an object, or null');
+
+        $this->instance->getParsedBody();
+    }
+
+    public function testGetParsedBodyMediaTypeNotExistingInParsers()
+    {
+        $fixtureMediaType = 'application/json';
+        $fixtureBody = 'body';
+
+        $this->instance = $this->getMockBuilder(HttpRequest::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getBody', 'getHeader'])
+            ->getMock();
+
+        $this->instance->expects($this->once())
+            ->method('getBody')
+            ->willReturn($fixtureBody);
+
+        $this->instance->expects($this->once())
+            ->method('getHeader')
+            ->with('content-type')
+            ->willReturn([$fixtureMediaType]);
+
+        $propertyBodyParsers = new ReflectionProperty($this->instance, 'bodyParsers');
+        $propertyBodyParsers->setAccessible(true);
+        $propertyBodyParsers->setValue($this->instance, []);
+
+        $this->assertNull($this->instance->getParsedBody());
+    }
+
+    public function testGetParsedBody()
+    {
+        $fixtureMediaType = 'application/json';
+        $fixtureBody = 'body';
+
+        $mockParser = $this->getMockBuilder(stdClass::class)
+            ->setMethods(['__invoke'])
+            ->getMock();
+
+        $mockParser->expects($this->once())
+            ->method('__invoke')
+            ->with($fixtureBody)
+            ->willReturn([]);
+
+        $this->instance = $this->getMockBuilder(HttpRequest::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getBody', 'getHeader'])
+            ->getMock();
+
+        $this->instance->expects($this->once())
+            ->method('getBody')
+            ->willReturn($fixtureBody);
+
+        $this->instance->expects($this->once())
+            ->method('getHeader')
+            ->with('content-type')
+            ->willReturn([$fixtureMediaType]);
+
+        $propertyBodyParsers = new ReflectionProperty($this->instance, 'bodyParsers');
+        $propertyBodyParsers->setAccessible(true);
+        $propertyBodyParsers->setValue($this->instance, ['application/json' => $mockParser]);
+
+        $this->assertEquals([], $this->instance->getParsedBody());
+
+        $propertyBodyParsed = new ReflectionProperty($this->instance, 'bodyParsed');
+        $propertyBodyParsed->setAccessible(true);
+        $this->assertEquals([], $propertyBodyParsed->getValue($this->instance));
+    }
+}

--- a/tests/Message/Request/HttpRequestTest.php
+++ b/tests/Message/Request/HttpRequestTest.php
@@ -94,7 +94,7 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
     {
         $fixtureBodyParsed = [];
 
-        $propertyBodyParsed = new ReflectionProperty($this->instance, 'bodyParsed');
+        $propertyBodyParsed = new ReflectionProperty($this->instance, 'parsedBody');
         $propertyBodyParsed->setAccessible(true);
         $propertyBodyParsed->setValue($this->instance, $fixtureBodyParsed);
 
@@ -235,7 +235,7 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals([], $this->instance->getParsedBody());
 
-        $propertyBodyParsed = new ReflectionProperty($this->instance, 'bodyParsed');
+        $propertyBodyParsed = new ReflectionProperty($this->instance, 'parsedBody');
         $propertyBodyParsed->setAccessible(true);
         $this->assertEquals([], $propertyBodyParsed->getValue($this->instance));
     }

--- a/tests/Message/Request/Parser/JsonParserTest.php
+++ b/tests/Message/Request/Parser/JsonParserTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use ObjectivePHP\Message\Request\Parser\JsonParser;
+
+class JsonParserTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var JsonParser
+     */
+    protected $instance;
+
+    public function setUp()
+    {
+        $this->instance = new JsonParser();
+    }
+
+    public function tearDown()
+    {
+        $this->instance = null;
+    }
+
+    public function testInvokeJsonDecodeFailed()
+    {
+        $fixtureData = 'test';
+
+        $this->assertEquals([], $this->instance->__invoke($fixtureData));
+    }
+
+    public function testInvoke()
+    {
+        $fixtureData = '{"id":1}';
+
+        $this->assertEquals(['id' => 1], $this->instance->__invoke($fixtureData));
+    }
+}


### PR DESCRIPTION
In case of an api, we need to get the body of request.
The body with php://input is readable only one time. So a parser to have this body multiple time can be useful.
Add an array to add multiple parsers if needed.